### PR TITLE
Actions direct versions

### DIFF
--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -56,7 +56,7 @@ jobs:
   timeout-minutes: 10
   steps:
     - name: Checkout Repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@v6
       with:
         fetch-depth: 1
 
@@ -74,13 +74,13 @@ jobs:
 
     - name: Setup Bun
       if: steps.check_files.outputs.has_files == 'true'
-      uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      uses: oven-sh/setup-bun@v2
       with:
         bun-version: ${{ inputs.bun-version || 'latest' }}
 
     - name: Cache Dependencies
       if: steps.check_files.outputs.has_files == 'true'
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+      uses: actions/cache@v5
       with:
         path: ~/.bun/install/cache
         key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}

--- a/.github/workflows/comprehensive-lint.yml
+++ b/.github/workflows/comprehensive-lint.yml
@@ -59,14 +59,14 @@ jobs:
     contents: write
   steps:
     - name: Checkout Repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@v6
       with:
         fetch-depth: 1
         ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
         token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
     - name: Cache Shellharden Binary
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+      uses: actions/cache@v5
       id: cache-shellharden
       with:
         path: ~/.local/bin/shellharden
@@ -116,7 +116,7 @@ jobs:
 
     - name: Commit Fixes
       if: inputs.commit-fixes && github.event.pull_request.head.repo.full_name == github.repository
-      uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
+      uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: 'style: apply shellharden [skip ci]'
         commit_user_name: github-actions[bot]
@@ -132,14 +132,14 @@ jobs:
     statuses: write
   steps:
     - name: Checkout Repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
     - name: Run MegaLinter
       id: ml
-      uses: oxsecurity/megalinter@42bb470545e359597e7f12156947c436e4e3fb9a # v9
+      uses: oxsecurity/megalinter@v9
       env:
         VALIDATE_ALL_CODEBASE: ${{ inputs.megalinter-validate-all }}
         GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
@@ -149,7 +149,7 @@ jobs:
 
     - name: Archive MegaLinter Reports
       if: always()
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      uses: actions/upload-artifact@v6
       with:
         name: megalinter-reports
         path: |
@@ -158,7 +158,7 @@ jobs:
 
     - name: Commit MegaLinter Fixes
       if: inputs.commit-fixes && steps.ml.outputs.has_updated_sources == 1
-      uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
+      uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: 'style: apply MegaLinter fixes [skip ci]'
         commit_user_name: megalinter-bot[bot]

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT || github.token }}
 
@@ -45,21 +45,21 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             ripgrep fd-find jq tmux rust-analyzer uv
 
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "25"
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
           token: ${{ secrets.PAT || github.token }}
-      - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           github-token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
       - name: Cache Bun dependencies
         if: steps.check_files.outputs.has_files == 'true'
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Dependabot metadata
         if: github.actor == 'dependabot[bot]'
         id: meta
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Auto-approve

--- a/.github/workflows/git-maintenance.yml
+++ b/.github/workflows/git-maintenance.yml
@@ -55,7 +55,7 @@ jobs:
   timeout-minutes: 30
   steps:
     - name: Checkout Repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         fetch-depth: 0
@@ -63,7 +63,7 @@ jobs:
 
     - name: Update Submodules
       id: submodules
-      uses: sgoudham/update-git-submodules@85ea2b33c7a1e8ac4746d0726c74f26d01c46816 # v2
+      uses: sgoudham/update-git-submodules@v2
       with:
         gitmodulesPath: ${{ inputs.gitmodules_path }}
         strategy: ${{ inputs.strategy }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Create Pull Request for Submodule Updates
         if: inputs.create_pr && steps.submodules.outputs.json != '' && steps.submodules.outputs.json != '[]'
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PAT || github.token }}
           commit-message: ${{ inputs.commit_message }}

--- a/.github/workflows/img-opt.yml
+++ b/.github/workflows/img-opt.yml
@@ -35,14 +35,14 @@ jobs:
   timeout-minutes: 15
   steps:
     - name: Checkout Repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@v6
       with:
         fetch-depth: 1
         ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
         token: ${{ secrets.PAT || github.token }}
 
     - name: Cache Image Tools
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+      uses: actions/cache@v5
       with:
         path: ~/.cache/image-tools
         key: ${{ runner.os }}-image-tools-v1
@@ -155,7 +155,7 @@ jobs:
         fi
     - name: Commit Image Optimizations
       if: steps.compress.outputs.changes_detected == 'true' && github.event.pull_request.head.repo.full_name == github.repository
-      uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
+      uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: "chore(img): optimize images [skip ci]"
         branch: ${{ github.head_ref || github.ref_name }}
@@ -165,7 +165,7 @@ jobs:
 
     - name: Comment on Pull Request
       if: steps.compress.outputs.changes_detected == 'true' && github.event_name == 'pull_request' && steps.stats.outputs.pct != ''
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      uses: actions/github-script@v8
       with:
         script: |
           github.rest.issues.createComment({

--- a/.github/workflows/jules-cleanup.yml
+++ b/.github/workflows/jules-cleanup.yml
@@ -9,7 +9,7 @@ jobs:
       actions: read
     steps:
       - name: Invoke Jules for Cleanup
-        uses: BeksOmega/jules-action@011e4a21fc5ca65e7dea8aa232acc99f8093fc3e # v1.0.0
+        uses: BeksOmega/jules-action@v1.0.0
         with:
           prompt: |
             Please analyze the codebase and perform maintenance tasks:

--- a/.github/workflows/jules-performance-improver.yml
+++ b/.github/workflows/jules-performance-improver.yml
@@ -8,7 +8,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: BeksOmega/jules-action@011e4a21fc5ca65e7dea8aa232acc99f8093fc3e # v1.0.0
+      - uses: BeksOmega/jules-action@v1.0.0
         with:
           prompt: |
             You are TURBO, a performance optimization agent. Hunt for speed improvements.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -107,7 +107,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: Release ${{ steps.version.outputs.version }}

--- a/.github/workflows/reusable-ci-python.yml
+++ b/.github/workflows/reusable-ci-python.yml
@@ -78,10 +78,10 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -111,10 +111,10 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -144,10 +144,10 @@ jobs:
       coverage: ${{ steps.coverage.outputs.percentage }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -197,7 +197,7 @@ jobs:
 
       - name: Upload coverage report
         if: inputs.upload-coverage
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
           fail_ci_if_error: false
@@ -206,7 +206,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: coverage.xml
@@ -228,10 +228,10 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -272,7 +272,7 @@ jobs:
 
       - name: Upload coverage report
         if: inputs.upload-coverage && matrix.python-version == fromJson(inputs.python-versions-matrix)[0]
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/reusable-ci-typescript.yml
+++ b/.github/workflows/reusable-ci-typescript.yml
@@ -83,13 +83,13 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'
@@ -115,13 +115,13 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'
@@ -147,13 +147,13 @@ jobs:
       coverage: ${{ steps.coverage.outputs.percentage }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'
@@ -190,7 +190,7 @@ jobs:
 
       - name: Upload coverage report
         if: inputs.upload-coverage
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
@@ -214,13 +214,13 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -234,7 +234,7 @@ jobs:
 
       - name: Upload coverage report
         if: inputs.upload-coverage && matrix.node-version == fromJson(inputs.node-versions-matrix)[0]
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
@@ -255,13 +255,13 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'
@@ -275,7 +275,7 @@ jobs:
 
       - name: Upload build artifacts
         if: inputs.upload-artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: ${{ inputs.working-directory }}/dist/

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -77,7 +77,7 @@ jobs:
       release-url: ${{ steps.create-release.outputs.url }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -214,14 +214,14 @@ jobs:
 
       - name: Download artifacts
         if: inputs.upload-artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@v7
         with:
           path: release-artifacts
         continue-on-error: true
 
       - name: Create GitHub Release
         id: create-release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.tag }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,10 +53,10 @@ jobs:
   if: inputs.scan_dependencies
   steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@v6
 
     - name: Dependency Review
-      uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4
+      uses: actions/dependency-review-action@v4
       with:
         fail-on-severity: ${{ inputs.fail_on_high && 'high' || 'critical' }}
         deny-licenses: GPL-3.0, AGPL-3.0
@@ -72,7 +72,7 @@ jobs:
         exit-code: ${{ inputs.fail_on_high && '1' || '0' }}
 
     - name: Upload Trivy results
-      uses: github/codeql-action/upload-sarif@9e907b5e64f6b83e7804b09294d44122997950d6 # v4
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: "trivy-results.sarif"
@@ -83,12 +83,12 @@ jobs:
   if: inputs.scan_secrets
   steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Gitleaks scan
-      uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+      uses: gitleaks/gitleaks-action@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -103,24 +103,24 @@ jobs:
   if: inputs.scan_sast
   steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@9e907b5e64f6b83e7804b09294d44122997950d6 # v4
+      uses: github/codeql-action/init@v4
       with:
         languages: javascript-typescript, python
         queries: security-and-quality
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@9e907b5e64f6b83e7804b09294d44122997950d6 # v4
+      uses: github/codeql-action/autobuild@v4
 
     - name: CodeQL Analysis
-      uses: github/codeql-action/analyze@9e907b5e64f6b83e7804b09294d44122997950d6 # v4
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:javascript-typescript,python"
 
     - name: Semgrep scan
-      uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
+      uses: semgrep/semgrep-action@v1
       with:
         config: >-
           p/security-audit
@@ -136,7 +136,7 @@ jobs:
   if: inputs.scan_container && inputs.container_image != ''
   steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@v6
 
     - name: Trivy container scan
       uses: aquasecurity/trivy-action@master
@@ -148,7 +148,7 @@ jobs:
         exit-code: ${{ inputs.fail_on_high && '1' || '0' }}
 
     - name: Upload container scan results
-      uses: github/codeql-action/upload-sarif@9e907b5e64f6b83e7804b09294d44122997950d6 # v4
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: "container-trivy.sarif"

--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -34,7 +34,7 @@ jobs:
   timeout-minutes: 15
   steps:
     - name: Checkout Repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
@@ -52,7 +52,7 @@ jobs:
 
     - name: Setup UV
       if: steps.check_files.outputs.has_files == 'true'
-      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: "3.13"
         activate-environment: "true"
@@ -74,7 +74,7 @@ jobs:
 
     - name: Lint with Ruff
       if: steps.check_files.outputs.has_files == 'true'
-      uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
+      uses: astral-sh/ruff-action@v3
 
     - name: Fix Lint Issues
       if: steps.check_files.outputs.has_files == 'true'
@@ -86,6 +86,6 @@ jobs:
 
     - name: Run Autofix
       if: steps.check_files.outputs.has_files == 'true'
-      uses: autofix-ci/action@7a166d7532b277f34e16238930461bf77f9d7ed8 # v1.3.3
+      uses: autofix-ci/action@v1.3.3
       with:
         github-token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}

--- a/actions/setup-node-pnpm/action.yml
+++ b/actions/setup-node-pnpm/action.yml
@@ -47,11 +47,11 @@ runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+      uses: pnpm/action-setup@v4
 
     - name: Setup Node.js
       id: node
-      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'

--- a/actions/setup-python-uv/action.yml
+++ b/actions/setup-python-uv/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Install uv
       id: uv
-      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         cache-dependency-glob: "${{ inputs.working-directory }}/uv.lock"

--- a/instructions/cicd-standards.instructions.md
+++ b/instructions/cicd-standards.instructions.md
@@ -55,7 +55,7 @@ permissions:
 - uses: actions/checkout@v4
 
 # WRONG: SHA pinning (harder to maintain, less readable)
-- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
 # WRONG: branch reference (vulnerable to compromise)
 - uses: actions/checkout@main
@@ -87,7 +87,7 @@ permissions:
 
 ### Caching
 ```yaml
-- uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f
+- uses: actions/cache@v4
   with:
     path: ~/.npm
     key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
@@ -106,7 +106,7 @@ strategy:
 
 ### Fast Checkout
 ```yaml
-- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+- uses: actions/checkout@v4
   with:
     fetch-depth: 1    # Shallow clone unless full history needed
 ```

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -15,8 +15,8 @@ Standards: See `instructions/cicd-standards.instructions.md`
 ## Security (Non-Negotiable)
 
 ```yaml
-# Example: SHA-pinned actions (see instructions/cicd-standards.instructions.md for org guidance)
-- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+# Example: Use version tags (see instructions/cicd-standards.instructions.md for org guidance)
+- uses: actions/checkout@v4
 
 # Minimal permissions
 permissions:
@@ -56,7 +56,7 @@ on:
 
 ```yaml
 # Caching
-- uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f
+- uses: actions/cache@v4
   with:
     path: ~/.cache/uv
     key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}


### PR DESCRIPTION
## Summary
Replaced SHA1 pins with direct version tags for GitHub Actions across all workflows and composite actions to improve readability and maintainability.

## Changes
- Updated all GitHub Actions in `.github/workflows/` and `actions/` to use version tags (e.g., `@vX`) instead of SHA1 pins.
- Modified documentation examples in `instructions/cicd-standards.instructions.md` and `skills/workflow-development/SKILL.md` to reflect the use of version tags.

## Checklist
- [ ] Scope is focused and related issues are linked
- [x] Documentation updated if needed
- [ ] Tests added or updated where applicable
- [x] No secrets or sensitive data included

---
<p><a href="https://cursor.com/background-agent?bcId=bc-d0edf3bf-da51-4860-b818-a154f13716c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0edf3bf-da51-4860-b818-a154f13716c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

