### PR TITLE
🔒 fix: use valid stable version for actions/setup-node

### DIFF
--- a/.github/workflows/reusable-ci-typescript.yml
+++ b/.github/workflows/reusable-ci-typescript.yml
@@ -89,7 +89,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'
@@ -121,7 +121,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'
@@ -153,7 +153,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'
@@ -220,7 +220,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -261,7 +261,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'

--- a/actions/setup-bun/action.yml
+++ b/actions/setup-bun/action.yml
@@ -13,7 +13,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '25'
           cache: bun

--- a/actions/setup-node-pnpm/action.yml
+++ b/actions/setup-node-pnpm/action.yml
@@ -51,7 +51,7 @@ runs:
 
     - name: Setup Node.js
       id: node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the use of a non-existent version (`v6`) of the `actions/setup-node` GitHub Action.

⚠️ **Risk:** Referencing a non-existent action version can cause workflows to fail unexpectedly. In some scenarios, it could also lead to a security risk if an attacker manages to register a malicious action under that tag (though unlikely for official `actions/` org).

🛡️ **Solution:** Downgraded all occurrences of `actions/setup-node@v6` to the latest stable major version `actions/setup-node@v4`. Verified YAML syntax and compatibility.

---
*PR created automatically by Jules for task [8257028203401813635](https://jules.google.com/task/8257028203401813635) started by @Ven0m0*