### PR TITLE
🧪 [testing improvement] Add test for invalid package.json parsing error

### DIFF
--- a/skills/lint-and-validate/tests/test_lint_runner.py
+++ b/skills/lint-and-validate/tests/test_lint_runner.py
@@ -49,6 +49,17 @@ def test_detect_node_project_with_tsconfig(tmp_path: Path):
     assert result["linters"][0]["name"] == "tsc"
 
 
+def test_detect_node_project_invalid_json(tmp_path: Path):
+    result = {"type": "unknown", "linters": []}
+    package_json = tmp_path / "package.json"
+    package_json.write_text("{ invalid json }")
+
+    detect_node_project(tmp_path, result)
+
+    assert result["type"] == "node"
+    assert len(result["linters"]) == 0
+
+
 def test_detect_python_project_pyproject(tmp_path: Path):
     result = {"type": "unknown", "linters": []}
     (tmp_path / "pyproject.toml").touch()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test for invalid package.json parsing error in `skills/lint-and-validate/scripts/lint_runner.py`.
📊 **Coverage:** What scenarios are now tested: Graceful handling of malformed `package.json` (e.g., syntax errors) during project type detection.
✨ **Result:** The improvement in test coverage: Increased reliability by ensuring the `detect_node_project` function does not crash when encountering corrupt configuration files.

---
*PR created automatically by Jules for task [6899871243438369827](https://jules.google.com/task/6899871243438369827) started by @Ven0m0*