### PR TITLE
🧪 Improve type coverage tests and fix Python stats logic

### DIFF
--- a/skills/lint-and-validate/scripts/type_coverage.py
+++ b/skills/lint-and-validate/scripts/type_coverage.py
@@ -174,13 +174,15 @@ def check_python_coverage(
             stats["any_count"] += len(any_matches)
 
             # Find functions with type hints
-            typed_funcs = RE_PY_TYPED_FUNC_PARAMS.findall(content)
-            typed_funcs += RE_PY_TYPED_FUNC_RETURN.findall(content)
-            stats["typed_functions"] += len(typed_funcs)
+            typed_indices = {m.start() for m in RE_PY_TYPED_FUNC_PARAMS.finditer(content)}
+            typed_indices.update(
+                m.start() for m in RE_PY_TYPED_FUNC_RETURN.finditer(content)
+            )
+            stats["typed_functions"] += len(typed_indices)
 
             # Find functions without type hints
-            all_funcs = RE_PY_ALL_FUNC.findall(content)
-            stats["untyped_functions"] += len(all_funcs) - len(typed_funcs)
+            all_indices = {m.start() for m in RE_PY_ALL_FUNC.finditer(content)}
+            stats["untyped_functions"] += len(all_indices - typed_indices)
 
         except Exception:
             continue

--- a/skills/lint-and-validate/tests/test_type_coverage.py
+++ b/skills/lint-and-validate/tests/test_type_coverage.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -5,7 +6,7 @@ from pathlib import Path
 scripts_dir = Path(__file__).parent.parent / "scripts"
 sys.path.append(str(scripts_dir))
 
-from type_coverage import check_typescript_coverage
+from type_coverage import check_typescript_coverage, check_python_coverage
 
 
 def test_check_typescript_coverage_no_files(tmp_path):
@@ -80,3 +81,80 @@ def test_check_typescript_coverage_multiple_files(tmp_path):
     result = check_typescript_coverage(tmp_path)
     assert result["files"] == 2
     assert result["stats"]["any_count"] == 2
+
+
+def test_check_python_coverage_basic(tmp_path):
+    """Test Python type hints coverage basic functionality."""
+    py_file = tmp_path / "test.py"
+    py_file.write_text(
+        """
+from typing import Any
+
+def typed_func(a: int) -> int:
+    return a
+
+def untyped_func(a):
+    return a
+
+def partial_typed_func(a: int):
+    return a
+
+def another_partial_typed_func(a) -> int:
+    return a
+
+x: Any = 1
+    """,
+        encoding="utf-8",
+    )
+
+    result = check_python_coverage(tmp_path)
+
+    # typed_func: typed (params + return)
+    # untyped_func: untyped
+    # partial_typed_func: typed (params)
+    # another_partial_typed_func: typed (return)
+    # Any count: 1
+
+    assert result["files"] == 1
+    assert result["stats"]["any_count"] == 1
+    assert result["stats"]["typed_functions"] == 3
+    assert result["stats"]["untyped_functions"] == 1
+
+
+def test_check_python_coverage_unreadable_file(tmp_path):
+    """Test Python coverage with an unreadable file."""
+    py_file = tmp_path / "unreadable.py"
+    py_file.write_text("def foo(): pass", encoding="utf-8")
+
+    # Make file unreadable
+    os.chmod(py_file, 0o000)
+
+    try:
+        # Should not raise exception
+        result = check_python_coverage(tmp_path)
+        assert result["files"] == 1
+        # Since it couldn't read the file, stats should be zero
+        assert result["stats"]["typed_functions"] == 0
+        assert result["stats"]["untyped_functions"] == 0
+    finally:
+        # Restore permissions for cleanup
+        os.chmod(py_file, 0o644)
+
+
+def test_check_typescript_coverage_unreadable_file(tmp_path):
+    """Test TypeScript coverage with an unreadable file."""
+    ts_file = tmp_path / "unreadable.ts"
+    ts_file.write_text("let a: any;", encoding="utf-8")
+
+    # Make file unreadable
+    os.chmod(ts_file, 0o000)
+
+    try:
+        # Should not raise exception
+        result = check_typescript_coverage(tmp_path)
+        assert result["files"] == 1
+        # Since it couldn't read the file, stats should be zero
+        assert result["stats"]["any_count"] == 0
+    finally:
+        # Restore permissions for cleanup
+        os.chmod(ts_file, 0o644)


### PR DESCRIPTION
This PR improves the testing and accuracy of the type coverage checker. It adds the requested error handling tests for unreadable files in both Python and TypeScript checks. Additionally, it fixes a logic bug in the Python coverage calculation that was discovered while implementing the new tests: previously, functions with both typed parameters and return types were counted twice, leading to incorrect coverage percentages and potentially negative untyped function counts. The fix uses set operations on match indices to ensure each function is accurately classified once.

---
*PR created automatically by Jules for task [837844844025829130](https://jules.google.com/task/837844844025829130) started by @Ven0m0*