### PR TITLE
🧹 refactor(hooks): extract duplicate jq parsing logic to helper

### DIFF
--- a/hooks/helper.sh
+++ b/hooks/helper.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Helper functions for hook scripts
+
+# Extracts a value from the INPUT variable using jq
+# $1: The jq path to extract
+# $2: (Optional) A default value to fall back to if jq extraction fails
+jq_extract() {
+  local path="$1"
+  local default_val="${2:-}"
+  printf '%s' "$INPUT" | jq -r "$path // \"$default_val\"" 2>/dev/null
+}

--- a/hooks/lint.sh
+++ b/hooks/lint.sh
@@ -2,7 +2,10 @@
 set -o pipefail
 
 INPUT=$(cat 2>/dev/null)
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // .toolName // ""' 2>/dev/null)
+
+# Source helper script
+source "$(dirname "$0")/helper.sh"
+TOOL_NAME=$(jq_extract '.tool_name // .toolName' '')
 
 if [[ "$TOOL_NAME" = "edit" || "$TOOL_NAME" = "create" ]]; then
   npm run lint-staged

--- a/hooks/post-tool-use
+++ b/hooks/post-tool-use
@@ -6,8 +6,11 @@ set -o pipefail
 
 INPUT=$(cat)
 
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // .toolName // ""' 2>/dev/null)
-OUTPUT=$(printf '%s' "$INPUT" | jq -r '.tool_response // .output // ""' 2>/dev/null)
+# Source helper script
+source "$(dirname "$0")/helper.sh"
+
+TOOL_NAME=$(jq_extract '.tool_name // .toolName' '')
+OUTPUT=$(jq_extract '.tool_response // .output' '')
 OUTPUT_BYTES=${#OUTPUT}
 
 # Log large outputs to stderr for visibility

--- a/hooks/pre-tool-use
+++ b/hooks/pre-tool-use
@@ -6,6 +6,9 @@ set -o pipefail
 
 INPUT=$(cat)
 
+# Source helper script
+source "$(dirname "$0")/helper.sh"
+
 # Helpers
 _allow() { exit 0; }
 _deny() {
@@ -17,30 +20,30 @@ _suppress_ok() {
   exit 0
 }
 
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // .toolName // ""' 2>/dev/null)
-COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
+TOOL_NAME=$(jq_extract '.tool_name // .toolName' '')
+COMMAND=$(jq_extract '.tool_input.command' '')
 
 # === SIZE LIMIT CHECKS ===
 case "$TOOL_NAME" in
   Write)
-    CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // ""' 2>/dev/null)
-    FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null)
+    CONTENT=$(jq_extract '.tool_input.content' '')
+    FILE_PATH=$(jq_extract '.tool_input.file_path' '')
     if ((${#CONTENT} > 102400)); then
       _deny "Write blocked: content exceeds 100KB (${#CONTENT}B) for $FILE_PATH. Break into smaller writes."
     fi
     _suppress_ok
     ;;
   Edit | StrReplace)
-    NEW=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // ""' 2>/dev/null)
-    FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null)
+    NEW=$(jq_extract '.tool_input.new_string' '')
+    FILE_PATH=$(jq_extract '.tool_input.file_path' '')
     if ((${#NEW} > 51200)); then
       _deny "Edit blocked: new_string exceeds 50KB (${#NEW}B) for $FILE_PATH. Use smaller targeted edits."
     fi
     _suppress_ok
     ;;
   Glob)
-    PATTERN=$(printf '%s' "$INPUT" | jq -r '.tool_input.pattern // ""' 2>/dev/null)
-    GLOB_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.path // ""' 2>/dev/null)
+    PATTERN=$(jq_extract '.tool_input.pattern' '')
+    GLOB_PATH=$(jq_extract '.tool_input.path' '')
     HOME_RE='^(/home/[^/]+|~|/Users/[^/]+|/root)/?$'
     if [[ "$PATTERN" =~ \*\* ]]; then
       if [[ "$GLOB_PATH" =~ $HOME_RE ]] || [[ -z "$GLOB_PATH" && "$PWD" =~ $HOME_RE ]]; then

--- a/hooks/read-guard
+++ b/hooks/read-guard
@@ -7,9 +7,12 @@ set -o pipefail
 
 INPUT=$(cat)
 
-FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null)
-OFFSET=$(printf '%s' "$INPUT" | jq -r '.tool_input.offset // 0' 2>/dev/null)
-LIMIT=$(printf '%s' "$INPUT" | jq -r '.tool_input.limit // 0' 2>/dev/null)
+# Source helper script
+source "$(dirname "$0")/helper.sh"
+
+FILE_PATH=$(jq_extract '.tool_input.file_path' '')
+OFFSET=$(jq_extract '.tool_input.offset // 0' '')
+LIMIT=$(jq_extract '.tool_input.limit // 0' '')
 
 _allow() { exit 0; }
 _deny() {

--- a/hooks/session-end
+++ b/hooks/session-end
@@ -6,7 +6,10 @@ set -o pipefail
 
 INPUT=$(cat)
 
-SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
+# Source helper script
+source "$(dirname "$0")/helper.sh"
+
+SESSION_ID=$(jq_extract '.session_id' '')
 STATE_DIR="${HOME}/.claude/.statusline"
 LOG_FILE="${HOME}/.claude/sessions.log"
 

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -6,7 +6,10 @@ set -o pipefail
 
 INPUT=$(cat)
 
-SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
+# Source helper script
+source "$(dirname "$0")/helper.sh"
+
+SESSION_ID=$(jq_extract '.session_id' '')
 
 # Initialize state directory
 STATE_DIR="${HOME}/.claude/.statusline"

--- a/hooks/stop
+++ b/hooks/stop
@@ -6,8 +6,11 @@ set -o pipefail
 
 INPUT=$(cat)
 
-STOP_REASON=$(printf '%s' "$INPUT" | jq -r '.stop_reason // ""' 2>/dev/null)
-SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
+# Source helper script
+source "$(dirname "$0")/helper.sh"
+
+STOP_REASON=$(jq_extract '.stop_reason' '')
+SESSION_ID=$(jq_extract '.session_id' '')
 
 LOG_FILE="${HOME}/.claude/sessions.log"
 mkdir -p "$(dirname "$LOG_FILE")"


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was duplicate `jq` logic for extracting values like `tool_name` or `file_path` from JSON input across 7 hook bash scripts. Extracted this to a shared `jq_extract` function in `hooks/helper.sh`.
💡 **Why:** Centralizing JSON extraction logic improves maintainability and reduces duplication.
✅ **Verification:** Verified via `bash -n hooks/*` (ignoring json configs), mocked invocations (e.g., `echo '{"tool_name":"Read"}' | bash hooks/post-tool-use`), code review, and full test suite run (`bun test`, `uv run pytest`).
✨ **Result:** Improved codebase cleanliness with zero behavioral changes.

---
*PR created automatically by Jules for task [16259499517721526395](https://jules.google.com/task/16259499517721526395) started by @Ven0m0*