### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/agentlint.yml
+++ b/.github/workflows/agentlint.yml
@@ -2,6 +2,9 @@ name: Lint LLM config files
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/.github/security/code-scanning/6](https://github.com/Ven0m0/.github/security/code-scanning/6)

In general, the problem is fixed by explicitly defining a `permissions` block either at the workflow root (applies to all jobs that don't override it) or within the specific job, and restricting the GITHUB_TOKEN to the minimal scopes needed (typically `contents: read` for a read-only linting workflow).

For this workflow, the best fix without changing behavior is to add a root-level `permissions` block granting only read access to repository contents. None of the steps (checking out code, setting up `uv`, running `claudelint`, and using `agent-sh/agnix`) obviously need to write to the repo or PRs. A suitable minimal configuration is:

```yaml
permissions:
  contents: read
```

This should be inserted near the top of `.github/workflows/agentlint.yml`, at the same indentation level as `on:` and `jobs:`. That way, every job (currently only `lint`) inherits these restricted permissions, resolving the CodeQL warning and enforcing least privilege. No additional imports, methods, or definitions are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
