### PR TITLE
🧹 chore: remove unused import Any in type coverage tests

### DIFF
--- a/skills/lint-and-validate/tests/test_type_coverage.py
+++ b/skills/lint-and-validate/tests/test_type_coverage.py
@@ -88,8 +88,6 @@ def test_check_python_coverage_basic(tmp_path):
     py_file = tmp_path / "test.py"
     py_file.write_text(
         """
-from typing import Any
-
 def typed_func(a: int) -> int:
     return a
 


### PR DESCRIPTION
This PR removes a dead code import of `Any` from `typing` within a test data string in `skills/lint-and-validate/tests/test_type_coverage.py`.

🎯 **What:** Removed `from typing import Any` from the Python test snippet used in `test_check_python_coverage_basic`.
💡 **Why:** This import was unused in the snippet and unnecessary for the `type_coverage.py` tool's analysis, which relies on regex matching for `: Any`. Removing it reduces noise in the test data.
✅ **Verification:** Ran `pytest skills/lint-and-validate/tests/test_type_coverage.py` and confirmed all 7 tests still pass. Verified with `ruff` that no new linting issues were introduced.
✨ **Result:** Cleaner test data and improved code health.

---
*PR created automatically by Jules for task [3735976002224403751](https://jules.google.com/task/3735976002224403751) started by @Ven0m0*