### PR TITLE
🧪 Add test for OSError handling in Python type coverage check

### DIFF
--- a/skills/lint-and-validate/scripts/type_coverage.py
+++ b/skills/lint-and-validate/scripts/type_coverage.py
@@ -141,6 +141,35 @@ def check_typescript_coverage(
         "issues": issues,
         "stats": stats,
     }
+
+
+def analyze_python_file(content: str) -> dict:
+    """Analyze Python content for type hint coverage."""
+    any_count = len(RE_PY_ANY.findall(content))
+
+    # Find all function definitions
+    all_indices = {m.start() for m in RE_PY_ALL_FUNC.finditer(content)}
+
+    # Find typed functions (parameters or return type)
+    typed_indices = {
+        m.start()
+        for m in chain(
+            RE_PY_TYPED_FUNC_PARAMS.finditer(content),
+            RE_PY_TYPED_FUNC_RETURN.finditer(content),
+        )
+    }
+
+    # Ensure we only count actual functions and avoid double counting
+    typed_count = len(typed_indices.intersection(all_indices))
+    untyped_count = len(all_indices - typed_indices)
+
+    return {
+        "any_count": any_count,
+        "typed_functions": typed_count,
+        "untyped_functions": untyped_count,
+    }
+
+
 def check_python_coverage(
     project_path: Path,
     max_files: Optional[int] = 30,

--- a/skills/lint-and-validate/tests/test_type_coverage.py
+++ b/skills/lint-and-validate/tests/test_type_coverage.py
@@ -164,6 +164,33 @@ def test_check_python_coverage_multiple_files(tmp_path):
     assert result["files"] == 2
     assert result["stats"]["typed_functions"] == 2
 
+
+def test_check_python_coverage_oserror(tmp_path):
+    """Test handling of OSError when reading a file."""
+    from unittest.mock import patch
+
+    (tmp_path / "good.py").write_text("def foo(x: int): pass")
+    bad_file = tmp_path / "bad.py"
+    bad_file.write_text("def bar(x): pass")
+
+    # Mock Path.read_text to raise OSError for 'bad.py'
+    original_read_text = Path.read_text
+
+    def mocked_read_text(self, *args, **kwargs):
+        if self.name == "bad.py":
+            raise OSError("Inaccessible file")
+        return original_read_text(self, *args, **kwargs)
+
+    with patch.object(Path, "read_text", autospec=True, side_effect=mocked_read_text):
+        result = check_python_coverage(tmp_path)
+
+    # Should have analyzed 2 files but only 1 successfully
+    assert result["files"] == 2
+    # Only good.py stats should be counted
+    assert result["stats"]["typed_functions"] == 1
+    assert result["stats"]["untyped_functions"] == 0
+
+
 def test_analyze_python_file():
     """Test analyze_python_file directly."""
     from type_coverage import analyze_python_file


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing test for `OSError` handling when reading Python files in `type_coverage.py`. I also had to implement the `analyze_python_file` function which was missing from the script but used by both the production code and existing tests.

📊 **Coverage:** 
- Added `test_check_python_coverage_oserror` which mocks `Path.read_text` to raise an `OSError`.
- Verified that `check_python_coverage` skips the unreadable file and correctly aggregates stats for readable files.
- Restored `analyze_python_file` functionality to ensure existing tests pass.

✨ **Result:** Improved test reliability and fixed broken Python coverage analysis. The full test suite for `type_coverage.py` now passes (10/10 tests).

---
*PR created automatically by Jules for task [2505803480928313533](https://jules.google.com/task/2505803480928313533) started by @Ven0m0*