### PR TITLE
Add official MCP servers to agents

### DIFF
--- a/agents/codebase-maintainer.agent.md
+++ b/agents/codebase-maintainer.agent.md
@@ -26,6 +26,11 @@ mcp-servers:
     command: npx
     args: ["-y", "yggdrasil-mcp"]
     tools: ["sequential_thinking"]
+  filesystem:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    tools: ["*"]
 ---
 
 # Codebase Maintainer

--- a/agents/coder.agent.md
+++ b/agents/coder.agent.md
@@ -30,6 +30,11 @@ mcp-servers:
     command: npx
     args: ["-y", "yggdrasil-mcp"]
     tools: ["sequential_thinking"]
+  filesystem:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    tools: ["*"]
 ---
 
 # Coder

--- a/agents/doc-writer.agent.md
+++ b/agents/doc-writer.agent.md
@@ -16,6 +16,11 @@ mcp-servers:
         "--mcp",
       ]
     tools: ["*"]
+  fetch:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-fetch"]
+    tools: ["*"]
 ---
 
 # Documentation Writer

--- a/agents/explorer.agent.md
+++ b/agents/explorer.agent.md
@@ -21,6 +21,11 @@ mcp-servers:
         "--mcp",
       ]
     tools: ["*"]
+  filesystem:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    tools: ["*"]
 ---
 
 # Explorer

--- a/agents/git.agent.md
+++ b/agents/git.agent.md
@@ -7,6 +7,11 @@ mcp-servers:
     command: npx
     args: ["-y", "yggdrasil-mcp"]
     tools: ["sequential_thinking"]
+  git:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-git"]
+    tools: ["*"]
 ---
 
 # Git & GitHub CLI Expert Agent

--- a/agents/janitor.agent.md
+++ b/agents/janitor.agent.md
@@ -26,6 +26,11 @@ mcp-servers:
     command: npx
     args: ["-y", "yggdrasil-mcp"]
     tools: ["sequential_thinking"]
+  filesystem:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    tools: ["*"]
 ---
 
 # Universal Janitor

--- a/agents/orchestrator.agent.md
+++ b/agents/orchestrator.agent.md
@@ -28,6 +28,21 @@ mcp-servers:
         "get_plan",
         "promote_plan",
       ]
+  memory:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-memory"]
+    tools: ["*"]
+  time:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-time"]
+    tools: ["*"]
+  git:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-git"]
+    tools: ["*"]
 ---
 
 # Orchestrator

--- a/agents/planner.agent.md
+++ b/agents/planner.agent.md
@@ -28,6 +28,16 @@ mcp-servers:
         "get_plan",
         "promote_plan",
       ]
+  memory:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-memory"]
+    tools: ["*"]
+  time:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-time"]
+    tools: ["*"]
 ---
 
 # Planner

--- a/agents/repo-architect.agent.md
+++ b/agents/repo-architect.agent.md
@@ -36,6 +36,16 @@ mcp-servers:
     type: http
     url: "https://learn.microsoft.com/api/mcp"
     tools: ["microsoft_docs_search", "microsoft_docs_fetch"]
+  filesystem:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    tools: ["*"]
+  memory:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-memory"]
+    tools: ["*"]
 ---
 
 # Repo Architect Agent

--- a/agents/researcher.agent.md
+++ b/agents/researcher.agent.md
@@ -11,6 +11,11 @@ mcp-servers:
     type: http
     url: "https://learn.microsoft.com/api/mcp"
     tools: ["microsoft_docs_search", "microsoft_docs_fetch"]
+  fetch:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-fetch"]
+    tools: ["*"]
 ---
 
 # Researcher

--- a/agents/reviewer.agent.md
+++ b/agents/reviewer.agent.md
@@ -30,6 +30,16 @@ mcp-servers:
     command: npx
     args: ["-y", "yggdrasil-mcp"]
     tools: ["sequential_thinking"]
+  git:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-git"]
+    tools: ["*"]
+  filesystem:
+    type: local
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    tools: ["*"]
 ---
 
 # Reviewer


### PR DESCRIPTION
Added official Model Context Protocol (MCP) servers to the relevant agents to expand their capabilities. The `fetch`, `filesystem`, `git`, `memory`, and `time` servers were added to the relevant agents (`explorer`, `coder`, `git`, `reviewer`, `planner`, etc) under `mcp-servers:` block.

---
*PR created automatically by Jules for task [15190885993088028084](https://jules.google.com/task/15190885993088028084) started by @Ven0m0*