### PR TITLE
🔒 Fix Unquoted EXCLUDE Environment Variable vulnerability in grep

### DIFF
--- a/actions/comprehensive-lint/action.yml
+++ b/actions/comprehensive-lint/action.yml
@@ -128,7 +128,7 @@ runs:
         mapfile -t files < <({
           find . -name "*.sh" -type f
           find . -name "*.bash" -type f -exec grep -l "^#!" {} +
-        } | grep -vE "$EXCLUDE" | sort -u)
+        } | { [[ -n "$EXCLUDE" ]] && grep -vE -- "$EXCLUDE" || cat; } | sort -u)
 
         if [[ ${#files[@]} -eq 0 ]]; then
           echo "No shell files found"


### PR DESCRIPTION
🎯 **What:** The `$EXCLUDE` environment variable was passed to `grep -vE`, potentially allowing option injection. Furthermore, if `$EXCLUDE` evaluates to an empty string, `grep -vE ""` matches every line, erroneously filtering out all files in the pipeline.

⚠️ **Risk:** A malicious user could craft an input starting with a hyphen (e.g., `-f`) that breaks `grep` syntax or causes unexpected command execution behavior. Additionally, empty exclusion strings would lead to unexpected logic failures by unintentionally dropping all legitimate files.

🛡️ **Solution:** The variable injection is fixed by explicitly signaling the end of options with `--` before `"$EXCLUDE"`. To address the empty pattern bug, the `grep` execution is conditionally bypassed using `[[ -n "$EXCLUDE" ]] && grep -vE -- "$EXCLUDE" || cat`, ensuring safe handling of empty exclusions.

---
*PR created automatically by Jules for task [10589987878769739442](https://jules.google.com/task/10589987878769739442) started by @Ven0m0*