### PR TITLE
🧹 Remove duplicate analyze_python_file function

### DIFF
--- a/skills/lint-and-validate/scripts/type_coverage.py
+++ b/skills/lint-and-validate/scripts/type_coverage.py
@@ -171,33 +171,6 @@ def check_typescript_coverage(
     }
 
 
-def analyze_python_file(content: str) -> dict:
-    """Analyze Python content for type hint coverage."""
-    any_count = len(RE_PY_ANY.findall(content))
-
-    # Find all function definitions
-    all_indices = {m.start() for m in RE_PY_ALL_FUNC.finditer(content)}
-
-    # Find typed functions (parameters or return type)
-    typed_indices = {
-        m.start()
-        for m in chain(
-            RE_PY_TYPED_FUNC_PARAMS.finditer(content),
-            RE_PY_TYPED_FUNC_RETURN.finditer(content),
-        )
-    }
-
-    # Ensure we only count actual functions and avoid double counting
-    typed_count = len(typed_indices.intersection(all_indices))
-    untyped_count = len(all_indices - typed_indices)
-
-    return {
-        "any_count": any_count,
-        "typed_functions": typed_count,
-        "untyped_functions": untyped_count,
-    }
-
-
 def check_python_coverage(
     project_path: Path,
     max_files: Optional[int] = 30,


### PR DESCRIPTION
🎯 **What:** Removed the duplicate definition of `analyze_python_file` in `skills/lint-and-validate/scripts/type_coverage.py`.
💡 **Why:** The function was defined twice (at line 110 and line 174) with nearly identical implementation. Removing the second definition improves maintainability and readability.
✅ **Verification:** Ran `PYTHONPATH=skills/lint-and-validate:skills/lint-and-validate/scripts pytest skills/lint-and-validate/tests` and confirmed that all relevant tests pass. Also verified file syntax with `python3 -m py_compile`.
✨ **Result:** A cleaner codebase with reduced redundancy.

---
*PR created automatically by Jules for task [5292039124805335136](https://jules.google.com/task/5292039124805335136) started by @Ven0m0*