### PR TITLE
chore(lint): reword console encoding comment to avoid false TODO flag

### DIFF
--- a/skills/lint-and-validate/scripts/lint_runner.py
+++ b/skills/lint-and-validate/scripts/lint_runner.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from utils import fix_windows_console_encoding
 
-# Fix Windows console encoding
+# Apply Windows console encoding fix
 # Swallow any errors here to preserve previous behavior where reconfigure() failures were non-fatal.
 try:
     fix_windows_console_encoding()

--- a/skills/lint-and-validate/scripts/type_coverage.py
+++ b/skills/lint-and-validate/scripts/type_coverage.py
@@ -28,7 +28,7 @@ RE_PY_ALL_FUNC = re.compile(r"def\s+\w+\s*\(")
 
 EXCLUDE_DIRS = {"venv", ".venv", "__pycache__", ".git", "node_modules"}
 
-# Fix Windows console encoding for Unicode output
+# Apply Windows console encoding fix for Unicode output
 fix_windows_console_encoding()
 
 


### PR DESCRIPTION
Reworded `# Fix Windows console encoding` to `# Apply Windows console encoding fix` in `type_coverage.py` and `lint_runner.py` to prevent it from being mistakenly matched as an actionable TODO item by code scanners.

---
*PR created automatically by Jules for task [14874249062865933809](https://jules.google.com/task/14874249062865933809) started by @Ven0m0*